### PR TITLE
hack in DESTDIR for make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ all:
 	make -C amcodec
 	
 install:
-	mkdir -p /usr/lib/aml_libs
+	mkdir -p $(DESTDIR)/usr/lib/aml_libs
 	make -C amavutils install
 	make -C amadec install
 	make -C amcodec install
-	install -m 0666 ld.so.conf /usr/lib/aml_libs
-	install -m 0666 aml.conf /etc/ld.so.conf.d
+	install -m 0666 ld.so.conf $(DESTDIR)/usr/lib/aml_libs
+	install -m 0666 aml.conf $(DESTDIR)/etc/ld.so.conf.d
                 
 clean:
 	make -C amavutils clean

--- a/amadec/Makefile
+++ b/amadec/Makefile
@@ -33,9 +33,9 @@ $(TARGET): $(TARGET_OBJS)
     
 
 install:
-	install -m 0644 libamadec.so /usr/lib/aml_libs
-	install -m 0644 include/*.h /usr/include
-	install -m 0644 *.h /usr/include
+	install -m 0644 libamadec.so $(DESTDIR)/usr/lib/aml_libs
+	install -m 0644 include/*.h $(DESTDIR)/usr/include
+	install -m 0644 *.h $(DESTDIR)/usr/include
 
 force:
 

--- a/amavutils/Makefile
+++ b/amavutils/Makefile
@@ -31,9 +31,9 @@ $(TARGET): $(TARGET_OBJS)
     
 
 install:
-	install -m 0644 ${TARGET} /usr/lib/aml_libs
-	install -m 0644 include/*.h /usr/include
-	install -m 0644 include/cutils -d /usr/include/cutils
+	install -m 0644 ${TARGET} $(DESTDIR)/usr/lib/aml_libs
+	install -m 0644 include/*.h $(DESTDIR)/usr/include
+	install -m 0644 include/cutils -d $(DESTDIR)/usr/include/cutils
 
 force:
 

--- a/amcodec/Makefile
+++ b/amcodec/Makefile
@@ -59,15 +59,15 @@ clean:$(CLRDIR)
 	rm -rf $(target_all)
 
 install:
-	install  -m 0644 libamcodec.so /usr/lib/aml_libs
+	install  -m 0644 libamcodec.so $(DESTDIR)/usr/lib/aml_libs
 	
-	install -m 0644 include -d /usr/include/amcodec
-	install -m 0644 include/*.h /usr/include/amcodec
-	install -m 0644 include/*.h /usr/include
+	install -m 0644 include -d $(DESTDIR)/usr/include/amcodec
+	install -m 0644 include/*.h $(DESTDIR)/usr/include/amcodec
+	install -m 0644 include/*.h $(DESTDIR)/usr/include
 	
-	install -m 0644 include/amports -d /usr/include/amports
-	install -m 0644 include/amports/*.h /usr/include/amports
+	install -m 0644 include/amports -d $(DESTDIR)/usr/include/amports
+	install -m 0644 include/amports/*.h $(DESTDIR)/usr/include/amports
 	
-	install -m 0644 include/ppmgr -d /usr/include/ppmgr
-	install -m 0644 include/ppmgr/*.h /usr/include/ppmgr
+	install -m 0644 include/ppmgr -d $(DESTDIR)/usr/include/ppmgr
+	install -m 0644 include/ppmgr/*.h $(DESTDIR)/usr/include/ppmgr
 


### PR DESCRIPTION
As if it's not bad enough already..

This lets me easily `make DESTDIR=${pkgdir} install` for packaging. Still works fine without specifying it.
